### PR TITLE
Add object-cache.php file to use mu-plugin drop-ins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@
 /mu-plugins/
 
 # drop-ins; these are managed at the platform-level
-/object-cache.php
 /db.php
 
 # Ignore temporary OS files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,6 @@ services:
       - ./local/public/wp-cli.yml:/var/www/html/wp-cli.yml
       - ./vip-config:/var/www/html/vip-config
       - ./plugins/vendor/automattic/vip-go-mu-plugins:/var/www/html/wp-content/mu-plugins
-      - ./plugins/vendor/automattic/vip-go-mu-plugins/drop-ins/object-cache/object-cache.php:/var/www/html/wp-content/object-cache.php
     environment:
       VIP_GO_ENV: local
       SMTPSERVER: mailhog

--- a/object-cache.php
+++ b/object-cache.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Include the object cache from the VIP mu-plugin bundle.
+ *
+ * Used on local only.
+ *
+ */
+
+if ( file_exists( __DIR__ . '/mu-plugins/drop-ins/object-cache.php' ) ) {
+	require_once __DIR__ . '/mu-plugins/drop-ins/object-cache.php';
+}


### PR DESCRIPTION
Some devs experience problems with `object-cache.php` file after new package install and composer update.

```
Starting forbescomau_wordpress_1 ... error

ERROR: for forbescomau_wordpress_1  Cannot start service wordpress: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:75: mounting "/home/milana/projects/forbes.com.au/plugins/vendor/automattic/vip-go-mu-plugins/drop-ins/object-cache/object-cache.php" to rootfs at "/var/www/html/wp-content/object-cache.php" caused: mount through procfd: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-veStarting forbescomau_mkcert_1    ... done
pe

ERROR: for wordpress  Cannot start service wordpress: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:75: mounting "/home/milana/projects/forbes.com.au/plugins/vendor/automattic/vip-go-mu-plugins/drop-ins/object-cache/object-cache.php" to rootfs at "/var/www/html/wp-content/object-cache.php" caused: mount through procfd: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
ERROR: Encountered errors while bringing up the project.
```

This fix simplifies the process of developing without the need to reload or rebuild the docker environment.
 